### PR TITLE
Fix buildpack OR bug in detect

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -22,13 +22,16 @@ func Detect(planParser PlanParser) packit.DetectFunc {
 			return packit.DetectResult{}, packit.Fail
 		}
 
-		return packit.DetectResult{
-			Plan: packit.BuildPlan{
+		plan := packit.BuildPlan{
 				Requires: requirements,
-				Or: []packit.BuildPlan{
+			}
+
+		if len(orRequirements) > 0 {
+				plan.Or = []packit.BuildPlan{
 					{Requires: orRequirements},
-				},
-			},
-		}, nil
+				}
+		}
+
+		return packit.DetectResult{ Plan: plan, }, nil
 	}
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -50,6 +50,50 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 				}
+			})
+
+			it("passes detection and has those deps in its final buildplan", func() {
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Plan).To(Equal(packit.BuildPlan{
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: "python",
+							Metadata: map[string]interface{}{
+								"launch": true,
+							},
+						},
+						{
+							Name: "ruby",
+							Metadata: map[string]interface{}{
+								"build": true,
+							},
+						},
+					},
+				}))
+
+				Expect(planParser.ParseCall.Receives.Path).To(Equal(filepath.Join(workingDir, "plan.toml")))
+			})
+		})
+
+		context("there are or requirements in the plan.toml", func() {
+			it.Before(func() {
+				planParser.ParseCall.Returns.Requirements = []packit.BuildPlanRequirement{
+					{
+						Name: "python",
+						Metadata: map[string]interface{}{
+							"launch": true,
+						},
+					},
+					{
+						Name: "ruby",
+						Metadata: map[string]interface{}{
+							"build": true,
+						},
+					},
+				}
 
 				planParser.ParseCall.Returns.OrRequirements = []packit.BuildPlanRequirement{
 					{

--- a/integration/or_test.go
+++ b/integration/or_test.go
@@ -1,0 +1,60 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testOr(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+
+		image     occam.Image
+		container occam.Container
+		name      string
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose()
+		docker = occam.NewDocker()
+
+		var err error
+		name, err = occam.RandomName()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+		Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+		Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+	})
+
+	it("should build a working OCI image for with the python runtime", func() {
+		var err error
+		image, _, err = pack.WithNoColor().Build.
+			WithNoPull().
+			WithBuildpacks(pythonRuntimeBuildpack, buildpack).
+			Execute(name, filepath.Join("testdata", "or"))
+		Expect(err).ToNot(HaveOccurred())
+
+		container, err = docker.Container.Run.WithCommand("python --version && python -m http.server $PORT").Execute(image.ID)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(container).Should(BeAvailable(), ContainerLogs(container.ID))
+
+		logs, err := docker.Container.Logs.Execute(container.ID)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(logs).To(MatchRegexp(`Python \d+\.\d+\.\d+`))
+	})
+}

--- a/integration/testdata/or/plan.toml
+++ b/integration/testdata/or/plan.toml
@@ -1,0 +1,18 @@
+[[requires]]
+  name = "python"
+
+  [requires.metadata]
+    launch = true
+
+[[requires]]
+  name = "pipenv"
+
+  [requires.metadata]
+    launch = true
+
+[[or]]
+  [[or.requires]]
+    name = "python"
+
+    [or.requires.metadata]
+      launch = true

--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -53,7 +53,7 @@ function util::tools::jam::install () {
 
   if [[ ! -f "${dir}/jam" ]]; then
     local version
-    version="v0.0.14"
+    version="v0.2.6"
 
     util::print::title "Installing jam ${version}"
     curl "https://github.com/paketo-buildpacks/packit/releases/download/${version}/jam-${os}" \
@@ -98,10 +98,10 @@ function util::tools::pack::install() {
 
   if [[ ! -f "${dir}/pack" ]]; then
     local version
-    version="v0.10.0"
+    version="v0.12.0"
 
     util::print::title "Installing pack ${version}"
-    curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-v0.10.0-${os}.tgz" \
+    curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
       --silent \
       --location \
       --output /tmp/pack.tgz

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -40,21 +40,40 @@ function tools::install() {
 }
 
 function images::pull() {
-    util::print::title "Pulling build image..."
-    docker pull "${CNB_BUILD_IMAGE:=gcr.io/paketo-buildpacks/build:full-cnb-cf}"
+  local builder
+  builder=""
 
-    util::print::title "Pulling run image..."
-    docker pull "${CNB_RUN_IMAGE:=gcr.io/paketo-buildpacks/run:full-cnb-cf}"
+  if [[ -f "${BUILDPACKDIR}/integration.json" ]]; then
+    builder="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
+  fi
 
-    util::print::title "Pulling cflinuxfs3 builder image..."
-    docker pull "${CNB_BUILDER_IMAGE:=gcr.io/paketo-buildpacks/builder:cflinuxfs3}"
+  if [[ "${builder}" == "null" || -z "${builder}" ]]; then
+    builder="index.docker.io/paketobuildpacks/builder:base"
+  fi
 
-    export CNB_BUILD_IMAGE
-    export CNB_RUN_IMAGE
-    export CNB_BUILDER_IMAGE
+  util::print::title "Pulling builder image..."
+  docker pull "${builder}"
 
-    util::print::title "Setting default pack builder image..."
-    pack set-default-builder "${CNB_BUILDER_IMAGE}"
+  util::print::title "Setting default pack builder image..."
+  pack set-default-builder "${builder}"
+
+  local run_image lifecycle_image
+  run_image="$(
+    docker inspect "${builder}" \
+      | jq -r '.[0].Config.Labels."io.buildpacks.builder.metadata"' \
+      | jq -r '.stack.runImage.image'
+  )"
+  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
+    docker inspect "${builder}" \
+      | jq -r '.[0].Config.Labels."io.buildpacks.builder.metadata"' \
+      | jq -r '.lifecycle.version'
+  )"
+
+  util::print::title "Pulling run image..."
+  docker pull "${run_image}"
+
+  util::print::title "Pulling lifecycle image..."
+  docker pull "${lifecycle_image}"
 }
 
 function token::fetch() {


### PR DESCRIPTION
Previously, the detect would always due to an empty OR buildplan. This PR only includes that buildplan if there are "or" requirements.